### PR TITLE
feat(cache): in-process TTL cache + IMS snapshot

### DIFF
--- a/__tests__/lib/cache.test.ts
+++ b/__tests__/lib/cache.test.ts
@@ -1,0 +1,77 @@
+import { getCached, cacheDelete, cacheDeletePrefix } from '../../lib/api';
+
+describe('in-memory cache helpers', () => {
+  beforeEach(() => {
+    // ensure a clean fake-timer state per test
+    jest.useRealTimers();
+    // restore Math.random in case other tests mock it
+    jest.spyOn(global.Math, 'random').mockRestore();
+  });
+
+  test('getCached caches result and avoids reloading', async () => {
+    const loader = jest.fn(async () => ({ value: 'ok' }));
+
+    const a = await getCached('test:key1', 5, loader);
+    const b = await getCached('test:key1', 5, loader);
+
+    expect(a).toEqual({ value: 'ok' });
+    expect(b).toEqual({ value: 'ok' });
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  test('cache expires after TTL and loader is called again', async () => {
+    // Make jitter deterministic (1.0)
+    jest.spyOn(global.Math, 'random').mockImplementation(() => 0.5);
+
+    jest.useFakeTimers('modern');
+    const start = Date.now();
+    jest.setSystemTime(start);
+
+    const loader = jest.fn(async () => ({ t: Date.now() }));
+
+    const first = await getCached('test:key2', 1, loader); // 1s ttl
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    // Advance time past TTL (jitter 1.0 -> expires at ~1000ms)
+    jest.setSystemTime(start + 1500);
+
+    const second = await getCached('test:key2', 1, loader);
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(second).not.toEqual(first);
+
+    jest.useRealTimers();
+    (global.Math.random as jest.Mock).mockRestore();
+  });
+
+  test('cacheDelete removes a single key', async () => {
+    const loader = jest.fn(async () => ({ v: Math.random() }));
+
+    const a = await getCached('test:key3', 10, loader);
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    cacheDelete('test:key3');
+
+    const b = await getCached('test:key3', 10, loader);
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(b).not.toEqual(a);
+  });
+
+  test('cacheDeletePrefix removes multiple keys with given prefix', async () => {
+    const loaderA = jest.fn(async () => 'A');
+    const loaderB = jest.fn(async () => 'B');
+
+    await getCached('pref:one', 10, loaderA);
+    await getCached('pref:two', 10, loaderB);
+
+    expect(loaderA).toHaveBeenCalledTimes(1);
+    expect(loaderB).toHaveBeenCalledTimes(1);
+
+    cacheDeletePrefix('pref:');
+
+    await getCached('pref:one', 10, loaderA);
+    await getCached('pref:two', 10, loaderB);
+
+    expect(loaderA).toHaveBeenCalledTimes(2);
+    expect(loaderB).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/api/users/privacy/route.ts
+++ b/app/api/users/privacy/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+import { getDb } from '../../../../lib/db';
+import { User } from '../../../../lib/entities/User';
+
+export async function GET(request: NextRequest) {
+  try {
+    const address = request.nextUrl.searchParams.get('address');
+
+    if (!address) {
+      return NextResponse.json(
+        { error: 'Address is required' },
+        { status: 400 }
+      );
+    }
+
+    const db = await getDb();
+    const repo = db.getRepository(User);
+    const user = await repo.findOne({ where: { address } });
+
+    return NextResponse.json({ isPublic: user?.isPublic ?? false });
+  } catch (error) {
+    console.error('Error fetching privacy state:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/users/snapshot/route.ts
+++ b/app/api/users/snapshot/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+import { getUserWithWorkersAndStats } from '../../../../lib/api';
+import { getDb } from '../../../../lib/db';
+import { User } from '../../../../lib/entities/User';
+import { UserStats } from '../../../../lib/entities/UserStats';
+
+// Lightweight snapshot endpoint with If-Modified-Since handling.
+export async function GET(request: NextRequest) {
+  try {
+    const address = request.nextUrl.searchParams.get('address');
+    if (!address) {
+      return NextResponse.json(
+        { error: 'Address is required' },
+        { status: 400 }
+      );
+    }
+
+    const ifModifiedSince = request.headers.get('if-modified-since');
+
+    // Try to use cached helper result first (avoid DB work)
+    // Access the internal cache via require of lib/api's internal accessor is not ideal,
+    // but we can attempt a lightweight DB check if no cache present.
+
+    const db = await getDb();
+
+    // Find latest timestamps cheaply using entity repositories
+    const userRepo = db.getRepository(User);
+    const userRow = await userRepo.findOne({
+      where: { address },
+      select: ['updatedAt'],
+    });
+
+    const statsMax = await db
+      .getRepository(UserStats)
+      .createQueryBuilder('s')
+      .select('MAX(s.timestamp)', 'maxTs')
+      .where('s.userAddress = :address', { address })
+      .getRawOne();
+
+    const userUpdatedAt = userRow?.updatedAt
+      ? new Date(userRow.updatedAt).getTime()
+      : 0;
+    const statsUpdatedAt = statsMax?.maxTs
+      ? new Date(statsMax.maxTs).getTime()
+      : 0;
+    // Normalize to seconds precision to match HTTP Last-Modified header granularity
+    const rawLastModifiedTs = Math.max(userUpdatedAt, statsUpdatedAt);
+    const lastModifiedTs =
+      Math.floor((rawLastModifiedTs || Date.now()) / 1000) * 1000;
+
+    if (ifModifiedSince) {
+      const sinceTs = Date.parse(ifModifiedSince);
+      // Allow a 1s tolerance for header rounding differences
+      if (!isNaN(sinceTs) && sinceTs >= lastModifiedTs) {
+        return new NextResponse(null, { status: 304 });
+      }
+    }
+
+    // Need to return full snapshot. Use existing helper which is cached.
+    const snapshot = await getUserWithWorkersAndStats(address);
+    if (!snapshot)
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const res = NextResponse.json(snapshot);
+    res.headers.set('Last-Modified', new Date(lastModifiedTs).toUTCString());
+    return res;
+  } catch (error) {
+    console.error('Error in snapshot endpoint:', error);
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/users/togglePrivacy/route.ts
+++ b/app/api/users/togglePrivacy/route.ts
@@ -3,8 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { toggleUserStatsPrivacy } from '../../../../lib/api';
 
 export async function POST(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const address = searchParams.get('address');
+  const address = request.nextUrl.searchParams.get('address');
 
   if (!address) {
     return NextResponse.json({ error: 'Address is required' }, { status: 400 });

--- a/components/PrivacyToggle.tsx
+++ b/components/PrivacyToggle.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 
 import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 
 interface PrivacyToggleProps {
   address: string;
@@ -13,7 +14,35 @@ const PrivacyToggle: React.FC<PrivacyToggleProps> = ({
   address,
   initialIsPublic,
 }) => {
+  const router = useRouter();
   const [isPublic, setIsPublic] = React.useState(initialIsPublic);
+  const [loadingState, setLoadingState] = React.useState(true);
+
+  // Fetch authoritative privacy state on mount (no-store so it bypasses server HTML cache)
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const resp = await fetch(`/api/users/privacy?address=${address}`, {
+          method: 'GET',
+          cache: 'no-store',
+        });
+        if (!resp.ok) throw new Error('Failed to fetch privacy');
+        const json = await resp.json();
+        if (mounted && typeof json.isPublic === 'boolean') {
+          setIsPublic(Boolean(json.isPublic));
+        }
+      } catch (err) {
+        // keep initialIsPublic as fallback
+        console.error('privacy fetch error', err);
+      } finally {
+        if (mounted) setLoadingState(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [address]);
 
   const mutation = useMutation({
     mutationFn: async () => {
@@ -28,8 +57,18 @@ const PrivacyToggle: React.FC<PrivacyToggleProps> = ({
       }
       return response.json();
     },
+    onMutate: async () => {
+      // optimistic update
+      setIsPublic((v) => !v);
+    },
     onSuccess: (data) => {
-      setIsPublic(data.isPublic);
+      setIsPublic(Boolean(data.isPublic));
+      // refresh server components for the current route so SSR fragments update
+      try {
+        router.refresh();
+      } catch {
+        // ignore router refresh failures
+      }
     },
     onError: (error) => {
       console.error('Error toggling privacy:', error);
@@ -41,12 +80,12 @@ const PrivacyToggle: React.FC<PrivacyToggleProps> = ({
       <button
         className={`btn btn-sm btn-primary ${isPublic ? '' : 'btn-outline'}`}
         onClick={() => mutation.mutate()}
-        disabled={mutation.isPending}
+        disabled={mutation.isPending || loadingState}
       >
         {isPublic ? 'Make Private' : 'Make Public'}
       </button>
       {mutation.isError && (
-        <p className="text-error mt-2">Failed to privacy setting.</p>
+        <p className="text-error mt-2">Failed to update privacy setting.</p>
       )}
     </div>
   );


### PR DESCRIPTION
Adds in-process TTL cache helpers with eviction, wraps heavy reads in cached getters, adds an IMS-capable snapshot endpoint at /api/users/snapshot, an authoritative privacy GET at /api/users/privacy, and updates the client privacy toggle to re-fetch authoritative state. Includes unit tests for cache helpers.