### PR TITLE
Handle empty pool status by clearing online_devices

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -190,7 +190,7 @@ async function seed() {
     await poolStatsRepository.save(entity);
     console.log('Database seeded successfully');
 
-    const userCount = parseInt(stats.Users ?? '0') || 0;
+    const userCount = poolStats.users || 0;
 
     if (stats.UserAgents && stats.UserAgents.length > 0) {
       await updateOnlineDevices(db, stats.UserAgents);


### PR DESCRIPTION
## Summary
- clear online_devices when pool.status reports Users=0 or no UserAgents
- keep stale data only when pool.status claims users but no UserAgents (warn)

## Testing
- pnpm test --runInBand
- pnpm build
- pnpm seed
- pnpm ts-node -r dotenv/config -P tsconfig.scripts.json scripts/updateUsers.ts