### PR TITLE
Fix: Connect countdown timer to dashboard and user pages

### DIFF
--- a/components/DashboardClient.tsx
+++ b/components/DashboardClient.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import { useEffect } from 'react';
+
 import Link from 'next/link';
 
 import PoolStatsChart from './PoolStatsChart';
 import PoolStatsDisplay from './PoolStatsDisplay';
+import { useRefresh } from '../lib/contexts/RefreshContext';
 import { useDashboardData } from '../lib/hooks/useDashboardData';
 import { DashboardPayload } from '../lib/types/dashboard';
 import {
@@ -17,7 +20,13 @@ export default function DashboardClient({
 }: {
   initialData: DashboardPayload;
 }) {
-  const { data, isLoading, error } = useDashboardData(initialData);
+  const { data, isLoading, error, refetch } = useDashboardData(initialData);
+  const { registerRefresh, unregisterRefresh } = useRefresh();
+
+  useEffect(() => {
+    registerRefresh(() => void refetch());
+    return () => unregisterRefresh();
+  }, [registerRefresh, unregisterRefresh, refetch]);
 
   // Show loading only on initial load when we have no data
   if (isLoading && !data) {

--- a/components/UserPageClient.tsx
+++ b/components/UserPageClient.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import { useEffect } from 'react';
+
 import PrivacyToggle from './PrivacyToggle';
 import UserStatsCharts from './UserStatsCharts';
 import WorkersTable from './WorkersTable';
+import { useRefresh } from '../lib/contexts/RefreshContext';
 import { useUserData } from '../lib/hooks/useUserData';
 import { UserDataPayload } from '../lib/types/user';
 import {
@@ -22,7 +25,13 @@ export default function UserPageClient({
   initialData: UserDataPayload;
   address: string;
 }) {
-  const { data, isLoading, error } = useUserData(address, initialData);
+  const { data, isLoading, error, refetch } = useUserData(address, initialData);
+  const { registerRefresh, unregisterRefresh } = useRefresh();
+
+  useEffect(() => {
+    registerRefresh(() => void refetch());
+    return () => unregisterRefresh();
+  }, [registerRefresh, unregisterRefresh, refetch]);
 
   // Show loading only on initial load when we have no data
   if (isLoading && !data) {


### PR DESCRIPTION
## Problem

The global countdown timer in the Header was not connected to Dashboard and User pages. Only leaderboard pages were registering with RefreshContext, so the timer appeared to do nothing on dashboard/user pages (only the invisible React Query 60s interval worked).

## Solution

- Add `useRefresh` hook to DashboardClient and UserPageClient
- Register `refetch()` callback on component mount
- Unregister on unmount via useEffect cleanup

## Result

- ✅ Timer now triggers manual refresh on **all** pages (dashboard, user, leaderboards)
- ✅ Consistent behavior across the entire app
- ✅ React Query handles edge cases (navigation during fetch, etc.)

## Testing

- Manual testing: verified timer triggers refresh on dashboard, user pages, and all leaderboards
- All existing tests pass (23 suites, 182 tests)
- Production build successful