### PR TITLE
Add DGB (DigiByte) coin support

### DIFF
--- a/__tests__/utils/validateBitcoinAddress.test.ts
+++ b/__tests__/utils/validateBitcoinAddress.test.ts
@@ -9,14 +9,20 @@ const BTC_TESTNET_BECH32 = 'tb1qn9quw86c6gv3642enrxaglvrqxt032kej9ydjh';
 const BTC_TESTNET_BECH32M = 'tb1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqp3mvzv';
 const BCH_CASHADDR = 'bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a';
 const BCH_CASHADDR_NO_PREFIX = 'qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a';
+const DGB_LEGACY = 'DGEX9JsfNuCCA3ovxAmUSM1GCea1BpY4Et';
+const DGB_P2SH = 'SQwL7TJrVbwyerVAGdUPMwHBhacNjrRzo9';
+const DGB_BECH32 = 'dgb1q6tf0myda7plmpksdqc8k4tf8q957z0fm0y9a5m';
+const DGB_BECH32M = 'dgb1p33wm0auhr9kkahzd6l0kqj85af4cswn276hsxg6zpz85xe2r0y8sev3mt5';
 
 interface CoinExpectations {
   acceptLegacy: boolean;    // 1..., 3... (shared encoding between BTC and BCH)
   acceptBTCBech32: boolean; // bc1q, bc1p, tb1q, tb1p
   acceptBCHCashAddr: boolean; // bitcoincash:q..., q...
+  acceptDGBLegacy: boolean; // D..., S...
+  acceptDGBBech32: boolean; // dgb1q..., dgb1p...
 }
 
-function runCommonTests({ acceptLegacy, acceptBTCBech32, acceptBCHCashAddr }: CoinExpectations) {
+function runCommonTests({ acceptLegacy, acceptBTCBech32, acceptBCHCashAddr, acceptDGBLegacy, acceptDGBBech32 }: CoinExpectations) {
   // Input validation — always rejects regardless of coin
   test('rejects null', () => {
     expect(validateBitcoinAddress(null as any)).toBe(false);
@@ -124,6 +130,23 @@ function runCommonTests({ acceptLegacy, acceptBTCBech32, acceptBCHCashAddr }: Co
   test(`${acceptBCHCashAddr ? 'accepts' : 'rejects'} BCH CashAddr without prefix`, () => {
     expect(validateBitcoinAddress(BCH_CASHADDR_NO_PREFIX)).toBe(acceptBCHCashAddr);
   });
+
+  // DGB address tests
+  test(`${acceptDGBLegacy ? 'accepts' : 'rejects'} DGB legacy address (D...)`, () => {
+    expect(validateBitcoinAddress(DGB_LEGACY)).toBe(acceptDGBLegacy);
+  });
+
+  test(`${acceptDGBLegacy ? 'accepts' : 'rejects'} DGB P2SH address (S...)`, () => {
+    expect(validateBitcoinAddress(DGB_P2SH)).toBe(acceptDGBLegacy);
+  });
+
+  test(`${acceptDGBBech32 ? 'accepts' : 'rejects'} DGB bech32 address (dgb1q...)`, () => {
+    expect(validateBitcoinAddress(DGB_BECH32)).toBe(acceptDGBBech32);
+  });
+
+  test(`${acceptDGBBech32 ? 'accepts' : 'rejects'} DGB bech32m address (dgb1p...)`, () => {
+    expect(validateBitcoinAddress(DGB_BECH32M)).toBe(acceptDGBBech32);
+  });
 }
 
 describe('validateBitcoinAddress — COIN unset (defaults to BTC)', () => {
@@ -137,7 +160,7 @@ describe('validateBitcoinAddress — COIN unset (defaults to BTC)', () => {
     delete process.env.COIN;
   });
 
-  runCommonTests({ acceptLegacy: true, acceptBTCBech32: true, acceptBCHCashAddr: false });
+  runCommonTests({ acceptLegacy: true, acceptBTCBech32: true, acceptBCHCashAddr: false, acceptDGBLegacy: false, acceptDGBBech32: false });
 });
 
 describe('validateBitcoinAddress — COIN=BTC', () => {
@@ -151,7 +174,7 @@ describe('validateBitcoinAddress — COIN=BTC', () => {
     delete process.env.COIN;
   });
 
-  runCommonTests({ acceptLegacy: true, acceptBTCBech32: true, acceptBCHCashAddr: false });
+  runCommonTests({ acceptLegacy: true, acceptBTCBech32: true, acceptBCHCashAddr: false, acceptDGBLegacy: false, acceptDGBBech32: false });
 });
 
 describe('validateBitcoinAddress — COIN=BCH', () => {
@@ -165,5 +188,19 @@ describe('validateBitcoinAddress — COIN=BCH', () => {
     delete process.env.COIN;
   });
 
-  runCommonTests({ acceptLegacy: true, acceptBTCBech32: false, acceptBCHCashAddr: true });
+  runCommonTests({ acceptLegacy: true, acceptBTCBech32: false, acceptBCHCashAddr: true, acceptDGBLegacy: false, acceptDGBBech32: false });
+});
+
+describe('validateBitcoinAddress — COIN=DGB', () => {
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_COIN;
+    process.env.COIN = 'DGB';
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_COIN;
+    delete process.env.COIN;
+  });
+
+  runCommonTests({ acceptLegacy: false, acceptBTCBech32: false, acceptBCHCashAddr: false, acceptDGBLegacy: true, acceptDGBBech32: true });
 });

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 const URI_SCHEMES: Record<string, string> = {
   BTC: 'bitcoin',
   BCH: 'bitcoincash',
+  DGB: 'digibyte',
 };
 
 const donationAddress = process.env.NEXT_PUBLIC_DONATION_ADDRESS || '';

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,8 @@ const mempoolLinkTag =
 const defaultDonationAddress =
   coin === 'BCH'
     ? 'qz85msghggld3smflk8flv0yza4c0c5drqgdgeruug'
+    : coin === 'DGB'
+    ? 'dgb1q6tf0myda7plmpksdqc8k4tf8q957z0fm0y9a5m'
     : 'bc1q8qkesw5kyplv7hdxyseqls5m78w5tqdfd40lf5';
 const donationAddress =
   process.env.DONATION_ADDRESS ||
@@ -21,7 +23,7 @@ const donationAddress =
 const defaultTheme =
   process.env.DEFAULT_THEME ||
   process.env.NEXT_PUBLIC_DEFAULT_THEME ||
-  (coin === 'BCH' ? 'dim' : 'dark');
+  (coin === 'BCH' ? 'dim' : coin === 'DGB' ? 'cupcake' : 'dark');
 
 const nextConfig = {
   webpack: (config) => {

--- a/utils/validateBitcoinAddress.ts
+++ b/utils/validateBitcoinAddress.ts
@@ -4,11 +4,29 @@ import * as bitcoin from 'bitcoinjs-lib';
 
 bitcoin.initEccLib(ecc);
 
+const DGB_NETWORK: bitcoin.Network = {
+  messagePrefix: '\x18DigiByte Signed Message:\n',
+  bech32: 'dgb',
+  bip32: { public: 0x0488b21e, private: 0x0488ade4 },
+  pubKeyHash: 0x1e,
+  scriptHash: 0x3f,
+  wif: 0x80,
+};
+
 export function validateBitcoinAddress(address: string): boolean {
   if (typeof address !== 'string') return false;
   if (address.length === 0) return false;
 
   const coin = process.env.NEXT_PUBLIC_COIN || process.env.COIN || 'BTC';
+
+  if (coin === 'DGB') {
+    try {
+      bitcoin.address.toOutputScript(address, DGB_NETWORK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
 
   if (coin === 'BCH') {
     // Accept CashAddr (with or without prefix)


### PR DESCRIPTION
Adds DigiByte (DGB) as a supported coin, following the same pattern as BCH.

## Changes

- **`utils/validateBitcoinAddress.ts`** — Add `DGB_NETWORK` params (`pubKeyHash: 0x1e`, `scriptHash: 0x3f`, `bech32: 'dgb'`) and a `COIN=DGB` branch that validates all four address formats: legacy (`D...`), P2SH (`S...`), bech32 (`dgb1q...`), and taproot (`dgb1p...`)
- **`components/Footer.tsx`** — Add `DGB: 'digibyte'` to `URI_SCHEMES`
- **`next.config.js`** — Add DGB default donation address (`dgb1q6tf0myda7plmpksdqc8k4tf8q957z0fm0y9a5m`) and `cupcake` default theme
- **`__tests__/utils/validateBitcoinAddress.test.ts`** — Extend `CoinExpectations` with `acceptDGBLegacy` / `acceptDGBBech32` flags, add DGB address constants, and add a `COIN=DGB` describe block (120 tests total, all passing)